### PR TITLE
Usage of osm_ids + locations when searching

### DIFF
--- a/include/ppr/common/routing_graph.h
+++ b/include/ppr/common/routing_graph.h
@@ -146,25 +146,6 @@ struct routing_graph {
                         area_rtree_size, rtree_opt);
   }
 
-  /*
-   * should only be used if it is unknown of which type the id is
-   * as there is an area, a node and a edge with the given id
-   * this function will return the node -> area -> edge
-   * @param id the osm-id from which you want to know the location
-   * @return the location of the given id
-   */
-  /*std::optional<node> find_osm_id(std::int64_t const& id) const {
-    auto node = find_osm_node(id);
-    if (node.has_value()) {
-      return node;
-    }
-    node = find_osm_edge(id);
-    if (node.has_value()) {
-      return node;
-    }
-    return find_osm_area(id);
-  }*/
-
   node* find_osm_node(std::int64_t const& id) const {
     for(auto const& node : data_->nodes_) {
       if(node->osm_id_ == id) {
@@ -176,9 +157,9 @@ struct routing_graph {
 
   edge* find_osm_edge(std::int64_t const& id) const {
     for(auto const& node : data_->nodes_) {
-      for(auto& out_edge : node->in_edges_) {
+      for(auto const& out_edge : node->out_edges_) {
         if(out_edge->info_->osm_way_id_ == id) {
-          return out_edge;
+          return out_edge.get();
         }
       }
     }
@@ -186,24 +167,9 @@ struct routing_graph {
   }
 
   area* find_osm_area(std::int64_t const& id) const {
-    /*auto first_a = data_->areas_.begin();
-    auto last_a = data_->areas_.end();
-    for(; first_a != last_a; ++first_a) {*/
     for(auto& area : data_->areas_) {
       if (area.osm_id_ == id) {
         return &area;
-        /*// Which location should be returned when the id of an area is requested? The middle point of an area?
-        int64_t lon = 0, lat = 0, count = 0;
-        for (auto node : area.get_nodes()) {
-          lon += node.location_.x();
-          lat += node.location_.y();
-          ++count;
-        }
-        int32_t lon32 = lon / count;
-        int32_t lat32 = lat / count;
-        return make_location(lon32, lat32);*/
-        // one random point of the area
-        // return first_a->get_nodes()[0].location_;
       }
     }
     return nullptr;

--- a/include/ppr/routing/input_pt.h
+++ b/include/ppr/routing/input_pt.h
@@ -20,9 +20,16 @@ struct input_pt {
   explicit input_pt(node const* node)
       : input_(node->location_),
         nearest_pt_(node->location_),
-        nearest_edge_(node->in_edges_[0]),
         in_area_(nullptr),
-        outside_of_area_(false) {}
+        outside_of_area_(false) {
+    if (node->in_edges_.empty()) {
+      if (!node->out_edges_.empty()) {
+        nearest_edge_ = node->out_edges_.at(0).get();
+      }
+    } else {
+      nearest_edge_ = node->in_edges_.at(0);
+    }
+  }
 
   explicit input_pt(location input, area const* in_area = nullptr)
       : input_(input),

--- a/include/ppr/routing/search.h
+++ b/include/ppr/routing/search.h
@@ -44,25 +44,13 @@ search_result find_routes(routing_graph const& g, location const& start,
                           bool allow_expansion = true);
 
 search_result find_routes(routing_graph const& g, std::int64_t const& start_id,
-                          osm_type const& type,
-                          std::vector<location> const& destinations,
+                          osm_type const& type, location const& start_loc,
+                          std::vector<std::int64_t> const& destination_ids,
+                          std::vector<osm_type> const& destination_types,
+                          std::vector<location> const& destination_locs,
                           search_profile const& profile,
                           search_direction dir = search_direction::FWD,
                           bool allow_expansion = true);
-
-search_result find_routes(routing_graph const& g, location const& start,
-                          std::vector<osm_type> const& end_type,
-                          std::vector<std::int64_t> const& destination_ids,
-                          search_profile const& profile,
-                          search_direction dir = search_direction::FWD,
-                          bool allow_expansion = true);
-
-search_result find_routes(routing_graph const& g, std::int64_t const& start_id,
-                          osm_type const& start_type,
-                          std::vector<osm_type> const& end_type,
-                          std::vector<std::int64_t> const& destination_ids,
-                          search_profile const& profile,
-                          search_direction dir = search_direction::FWD);
 
 std::vector<input_pt> find_destinations(routing_graph const& g,
                                         std::vector<osm_type> const& end_type,

--- a/include/ppr/routing/statistics.h
+++ b/include/ppr/routing/statistics.h
@@ -30,6 +30,8 @@ struct routing_statistics {
   int attempts_ = 0;
   int start_pts_extended_ = 0;
   int destination_pts_extended_ = 0;
+  bool start_is_location = false;
+  std::vector<bool> destination_is_location = {};
   double d_start_pts_ = 0;
   double d_start_pts_extended_ = 0;
   double d_destination_pts_ = 0;

--- a/src/backend/http_server.cc
+++ b/src/backend/http_server.cc
@@ -118,25 +118,9 @@ struct http_server::impl {
           req, R"({"error": "Missing or invalid start/destination locations"})",
           http::status::bad_request));
     }
-    search_result result;
-    if (r.start_.valid()) {
-      if (r.destination_.valid()) {
-        result = find_routes(graph_, r.start_,
-                             {r.destination_}, r.profile_);
-      } else {
-        result = find_routes(graph_, r.start_, {r.destination_type_},
-                             {r.osm_id_destination_}, r.profile_);
-      }
-    } else {
-      if (r.destination_.valid()) {
-        result = find_routes(graph_, r.osm_id_start_, r.start_type_,
-                             {r.destination_}, r.profile_);
-      } else {
-        result = find_routes(graph_, r.osm_id_start_, r.start_type_,
-                             {r.destination_type_}, {r.osm_id_destination_},
-                             r.profile_);
-      }
-    }
+    search_result result = find_routes(graph_, r.osm_id_start_, r.start_type_, r.start_,
+                                       {r.osm_id_destination_}, {r.destination_type_},
+                                       {r.destination_}, r.profile_);
     return cb(json_response(req, routes_to_route_response(result, r)));
   }
 

--- a/src/cmd/id-searcher/main.cc
+++ b/src/cmd/id-searcher/main.cc
@@ -14,12 +14,22 @@ using namespace ppr::routing;
 
 void find_locations_by_ids(std::vector<int64_t> const& ids, routing_graph const& rg) {
   for(auto id: ids) {
-    auto myLocation = rg.find_osm_id(id);
+    auto nodeLocation = rg.find_osm_node(id);
+    auto edgeLocation = rg.find_osm_edge(id);
+    auto areaLocation = rg.find_osm_area(id);
 
-    if (myLocation.has_value()) {
-      std::cout << myLocation.value() << std::endl;
+    if (nodeLocation != nullptr) {
+      std::cout << "NODE: " << nodeLocation->location_ << std::endl;
     } else {
-      std::cout << "No Location with the ID " << id << " found!" << std::endl;
+      if (edgeLocation != nullptr) {
+        std::cout << "EDGE: " << edgeLocation->path_.at(0) << std::endl;
+      } else {
+        if (areaLocation != nullptr) {
+          std::cout << "AREA: " << areaLocation->polygon_.inner_.at(0).at(0).location_ << std::endl;
+        } else {
+          std::cout << "No Location with the ID " << id << " found!" << std::endl;
+        }
+      }
     }
   }
 }
@@ -64,38 +74,24 @@ int main(int argc, char const* argv[]) {
   std::cout << "Creating r-trees..." << std::endl;
   rg.prepare_for_routing();
 
-  std::vector<int64_t> ids{1096061370, 4743094, 1091110991, 1101668808, 967515792, 463507836, 182243822};
+  std::vector<int64_t> ids{391332763, 5327813, 48928244, 3945358660, 4210513525};
   auto start_type = ppr::routing::osm_type::UNKNOWN;
-  auto end_type = std::vector{start_type, start_type, start_type};
-  auto end_type2 = std::vector{start_type};
-  auto destination = std::vector{std::int64_t{1091110991}, std::int64_t{967515792}, std::int64_t{4743094}};
-  auto destination2 = std::vector{std::int64_t{182243822}};
+  //auto end_type = std::vector{start_type, start_type, start_type};
+  //auto end_type2 = std::vector{start_type};
+  //auto destination = std::vector{std::int64_t{1091110991}, std::int64_t{967515792}, std::int64_t{4743094}};
+  //auto destination2 = std::vector{std::int64_t{182243822}};
   auto profile = search_profile();
   auto direction = search_direction::FWD;
-  auto start_location = make_location(9.782356, 50.321303);
-  auto end_location = std::vector{make_location(9.768958, 50.326320)};
-  auto response = find_routes(rg, 1101668808,
-                              start_type,
-                              end_type,
-                              destination,
-                              profile,
-                              direction,
-                              true);
-  auto response2 = find_routes(rg, 463507836,
-                              start_type,
-                              end_type2,
-                              destination2,
-                              profile,
-                              direction,
-                              true);
-  auto response3 = find_routes(rg, start_location,
+  //auto start_location = make_location(9.782356, 50.321303);
+  //auto end_location = std::vector{make_location(9.768958, 50.326320)};
+  /*auto response3 = find_routes(rg, start_location,
                                end_location, profile, direction,
-                               true);
-  print_route(response);
-  std::cout << "2." << std::endl;
-  print_route(response2);
-  std::cout << "3." << std::endl;
-  print_route(response3);
+                               true);*/
+  //print_route(response);
+  //std::cout << "2." << std::endl;
+  //print_route(response2);
+  //std::cout << "3." << std::endl;
+  //print_route(response3);
 
   find_locations_by_ids(ids, rg);
 

--- a/src/preprocessing/osm_graph/extractor.cc
+++ b/src/preprocessing/osm_graph/extractor.cc
@@ -189,6 +189,8 @@ private:
     return v;
   }
 
+  /* TODO: use node_map_ to find the nodes later
+    * additionally create a new map for ways and relations*/
   osm_graph& graph_;
   std::unordered_map<std::int64_t, struct osm_node*> node_map_;
   std::unordered_set<osmium::object_id_type> const& multipolygon_ways_;

--- a/src/routing/search.cc
+++ b/src/routing/search.cc
@@ -131,129 +131,97 @@ search_result find_routes(routing_graph const& g, location const& start,
   return result;
 }
 
-// find routes with locations as destination and an osm-id of a given type as start
-search_result find_routes(routing_graph const& g, std::int64_t const& start_id,
-                          osm_type const& type,
-                          std::vector<location> const& destinations,
-                          search_profile const& profile, search_direction dir,
-                          bool allow_expansion) {
-  auto t_start = timing_now();
-  search_result result;
-  auto start = find_start(g, start_id, type);
-  if(!start) {
-    result.stats_.d_total_ = ms_since(t_start);
-    return result;
-  }
-  mapped_pt mapped_start = {start.input_, {start}};
-  auto const t_after_start = timing_now();
-  result.stats_.d_start_pts_ = ms_between(t_start, t_after_start);
-  std::vector<mapped_pt> mapped_goals;
-  mapped_goals.reserve(destinations.size());
-  std::transform(
-      begin(destinations), end(destinations), std::back_inserter(mapped_goals),
-      [&](location const& loc) {
-        return mapped_pt{
-            loc, nearest_points(g, loc, initial_max_pt_query,
-                                initial_max_pt_count, initial_max_pt_dist)};
-      });
-  auto const t_after_dest = timing_now();
-  result.stats_.d_destination_pts_ = ms_between(t_after_start, t_after_dest);
-  // 1st attempt: only nearest start + goal points
-  find_routes(result, mapped_start, mapped_goals, profile, dir);
-  if (allow_expansion && !all_goals_reached(result)) {
-    // 2nd attempt: expand goal points
-    auto const t_before_expand_dest = timing_now();
-    for (std::size_t i = 0; i < destinations.size(); i++) {
-      if (result.routes_[i].empty()) {
-        mapped_goals[i].second =
-            nearest_points(g, destinations[i], expanded_max_pt_query,
-                           expanded_max_pt_count, expanded_max_pt_dist);
-        result.stats_.destination_pts_extended_++;
-      }
-    }
-    result.stats_.d_destination_pts_extended_ =
-        ms_since(t_before_expand_dest);
-    find_routes(result, mapped_start, mapped_goals, profile, dir);
-  }
-  result.stats_.d_total_ = ms_since(t_start);
-  return result;
-}
-
-// find routes with a location as start and osm-ids as destinations
-search_result find_routes(routing_graph const&g, location const& start,
-                          std::vector<osm_type> const& end_type,
+// find routes with osm-ids, as start and/or destinations
+// start_loc and destination_locs are only used if the start/none of the destinations
+// are found using the osm_ids
+search_result find_routes(routing_graph const&g, std::int64_t const& start_id,
+                          osm_type const& start_type, location const& start_loc,
                           std::vector<std::int64_t> const& destination_ids,
+                          std::vector<osm_type> const& destination_types,
+                          std::vector<location> const& destination_locs,
                           search_profile const& profile, search_direction dir,
                           bool allow_expansion) {
+  assert(destination_ids.size() == destination_types.size());
+  assert(destination_ids.size() == destination_locs.size());
   auto t_start = timing_now();
   search_result result;
-  mapped_pt mapped_start = {
-      start, nearest_points(g, start, initial_max_pt_query,
-                            initial_max_pt_count, initial_max_pt_dist)};
+  // search whether the osm object defined by id+type exists
+  auto start = find_start(g, start_id, start_type);
+  mapped_pt mapped_start;
+  // if the osm object is not found use the start location as start
+  if(!start) {
+    mapped_start = {start_loc,
+                    nearest_points(g, start_loc, initial_max_pt_query,
+                                   initial_max_pt_count, initial_max_pt_dist)};
+    result.stats_.start_is_location = true;
+  } else {
+    mapped_start = {start.input_, {start}};
+  }
   auto const t_after_start = timing_now();
   result.stats_.d_start_pts_ = ms_between(t_start, t_after_start);
-  auto goals = find_destinations(g, end_type, destination_ids);
-  if (goals.empty()) {
-    result.stats_.d_total_ = ms_since(t_start);
-    return result;
-  }
+  // search whether the osm objects defined by id+type exist
+  auto goals = find_destinations(g, destination_types, destination_ids);
   std::vector<mapped_pt> mapped_goals;
-  for(auto const& goal : goals) {
-    mapped_goals.emplace_back(mapped_pt{goal.input_, {goal}});
+  mapped_goals.reserve(destination_ids.size());
+  //check whether the osm objects were found and if any weren't found use the location for that destination
+  for(int i = 0; i < goals.size(); ++i) {
+    if (goals.at(i)) {
+      mapped_goals.emplace_back(mapped_pt{goals.at(i).input_, {goals.at(i)}});
+      result.stats_.destination_is_location[i] = false;
+    } else {
+      mapped_goals.emplace_back(
+          destination_locs.at(i),
+          nearest_points(g, destination_locs.at(i), initial_max_pt_query,
+                              initial_max_pt_count, initial_max_pt_dist));
+      result.stats_.destination_is_location[i] = true;
+    }
   }
   auto const t_after_dest = timing_now();
   result.stats_.d_destination_pts_ = ms_between(t_after_start, t_after_dest);
   // 1st attempt: only nearest start + goal points
   find_routes(result, mapped_start, mapped_goals, profile, dir);
   if (allow_expansion && !all_goals_reached(result)) {
+    auto const orig_start = mapped_start.second;
     // 2nd attempt: expand start point
     auto const t_before_expand_start = timing_now();
     mapped_start.second =
-        nearest_points(g, start, expanded_max_pt_query, expanded_max_pt_count,
+        nearest_points(g, start_loc, expanded_max_pt_query, expanded_max_pt_count,
                        expanded_max_pt_dist);
     result.stats_.start_pts_extended_++;
     result.stats_.d_start_pts_extended_ = ms_since(t_before_expand_start);
     find_routes(result, mapped_start, mapped_goals, profile, dir);
+    if (!all_goals_reached(result)) {
+      // 3rd attempt: expand goal points
+      auto const expanded_start = mapped_start.second;
+      mapped_start.second = orig_start;
+      auto const t_before_expand_dest = timing_now();
+      for (std::size_t i = 0; i < destination_locs.size(); i++) {
+        if (result.routes_[i].empty()) {
+          mapped_goals[i].second =
+              nearest_points(g, destination_locs[i], expanded_max_pt_query,
+                             expanded_max_pt_count, expanded_max_pt_dist);
+          result.stats_.destination_pts_extended_++;
+        }
+      }
+      result.stats_.d_destination_pts_extended_ =
+          ms_since(t_before_expand_dest);
+      find_routes(result, mapped_start, mapped_goals, profile, dir);
+      if (!all_goals_reached(result)) {
+        // 4th attempt: expand start and goal points
+        mapped_start.second = expanded_start;
+        find_routes(result, mapped_start, mapped_goals, profile, dir);
+      }
+    }
   }
-  result.stats_.d_total_ = ms_since(t_start);
-  return result;
-}
-
-// find routes with osm-ids, as start and destinations
-search_result find_routes(routing_graph const&g, std::int64_t const& start_id,
-                          osm_type const& start_type,
-                          std::vector<osm_type> const& end_type,
-                          std::vector<std::int64_t> const& destination_ids,
-                          search_profile const& profile, search_direction dir) {
-  auto t_start = timing_now();
-  search_result result;
-  auto start = find_start(g, start_id, start_type);
-  if(!start) {
-    result.stats_.d_total_ = ms_since(t_start);
-    return result;
-  }
-  mapped_pt mapped_start = {start.input_, {start}};
-  auto const t_after_start = timing_now();
-  result.stats_.d_start_pts_ = ms_between(t_start, t_after_start);
-  auto goals = find_destinations(g, end_type, destination_ids);
-  if (goals.empty()) {
-    result.stats_.d_total_ = ms_since(t_start);
-    return result;
-  }
-  std::vector<mapped_pt> mapped_goals;
-  for(auto const& goal : goals) {
-    mapped_goals.emplace_back(mapped_pt{goal.input_, {goal}});
-  }
-  auto const t_after_dest = timing_now();
-  result.stats_.d_destination_pts_ = ms_between(t_after_start, t_after_dest);
-  // 1st attempt: only nearest start + goal points
-  find_routes(result, mapped_start, mapped_goals, profile, dir);
   result.stats_.d_total_ = ms_since(t_start);
   return result;
 }
 
 input_pt find_start(routing_graph const& g, std::int64_t const& start_id,
                     osm_type const& start_type) {
+  if (start_id == -1) {
+    return {};
+  }
   area* area;
   edge* edge;
   node* node;
@@ -271,7 +239,7 @@ input_pt find_start(routing_graph const& g, std::int64_t const& start_id,
     case osm_type::EDGE:
       edge = g.find_osm_edge(start_id);
       if (edge != nullptr) {
-        return nearest_pt_on_edge(edge, edge->path_[0]);
+        return input_pt{edge->from_};
       }
     default:
       area = g.find_osm_area(start_id);
@@ -280,7 +248,7 @@ input_pt find_start(routing_graph const& g, std::int64_t const& start_id,
       }
       edge = g.find_osm_edge(start_id);
       if (edge != nullptr) {
-        return nearest_pt_on_edge(edge, edge->path_[0]);
+        return input_pt{edge->from_};
       }
       node = g.find_osm_node(start_id);
       if (node != nullptr) {
@@ -299,38 +267,53 @@ std::vector<input_pt> find_destinations(routing_graph const& g,
   node* node;
   auto type_it = end_type.begin();
   for (std::int64_t destination_id : destination_ids) {
+    if (destination_id == -1) {
+      type_it++;
+      destinations.emplace_back();
+      continue;
+    }
     switch (*(type_it++)._Ptr) {
       case osm_type::NODE:
         node = g.find_osm_node(destination_id);
         if (node != nullptr) {
-          destinations.emplace_back(input_pt{node});
+          destinations.emplace_back(node);
+        } else {
+          destinations.emplace_back();
         }
         break;
       case osm_type::AREA:
         area = g.find_osm_area(destination_id);
         if (area != nullptr) {
-          destinations.emplace_back(input_pt{area->get_middle(), area});
+          destinations.emplace_back(area->get_middle(), area);
+        } else {
+          destinations.emplace_back();
         }
         break;
       case osm_type::EDGE:
         edge = g.find_osm_edge(destination_id);
         if (edge != nullptr) {
-          destinations.emplace_back(nearest_pt_on_edge(edge, edge->path_[0]));
+          destinations.emplace_back(edge->from_);
+        } else {
+          destinations.emplace_back();
         }
         break;
       default:
         area = g.find_osm_area(destination_id);
         if (area != nullptr) {
-          destinations.emplace_back(input_pt{area->get_middle(), area});
+          destinations.emplace_back(area->get_middle(), area);
+          continue;
         }
         edge = g.find_osm_edge(destination_id);
         if (edge != nullptr) {
-          destinations.emplace_back(nearest_pt_on_edge(edge, edge->path_[0]));
+          destinations.emplace_back(edge->from_);
+          continue;
         }
         node = g.find_osm_node(destination_id);
         if (node != nullptr) {
-          destinations.emplace_back(input_pt{node});
+          destinations.emplace_back(node);
+          continue;
         }
+        destinations.emplace_back();
     }
   }
   return destinations;


### PR DESCRIPTION
When searching a footpath using find_routes you have the same method for searching with ids or with locations. The method first tries to find the osm objects. If it does not it uses the given locations as start/destination.