### PR TITLE
Faster search for osm_ids on edges and areas

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -52,14 +52,14 @@ jobs:
             cc: gcc-10
             mode: Release
             mimalloc: on
-            os: ubuntu-20.04
+            os: ubuntu-latest
             artifact: linux
           - name: GCC 10 Debug
             cxx: g++-10
             cc: gcc-10
             mode: Debug
             mimalloc: on
-            os: ubuntu-20.04
+            os: ubuntu-latest
           - name: Clang 14 Release
             cxx: clang++-14
             cc: clang-14
@@ -67,7 +67,7 @@ jobs:
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
-            os: ubuntu-20.04
+            os: ubuntu-latest
           - name: Clang Tidy
             cxx: clang++-14
             cc: clang-14
@@ -76,7 +76,7 @@ jobs:
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             lint: true
-            os: ubuntu-20.04
+            os: ubuntu-latest
           - key: Clang 14 Sanitizer
             cxx: clang++-14
             cc: clang-14
@@ -85,7 +85,7 @@ jobs:
             cflags: -fsanitize=address,undefined -fno-omit-frame-pointer
             cxxflags: -fsanitize=address,undefined -fno-omit-frame-pointer -stdlib=libc++
             ldflags: -lc++abi
-            os: ubuntu-20.04
+            os: ubuntu-latest
     env:
       BUILDCACHE_COMPRESS: true
       BUILDCACHE_DIRECT_MODE: true
@@ -113,7 +113,7 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 14
           rm llvm.sh
-          sudo apt-get install -y --no-install-recommends libc++-14-dev libc++abi-14-dev clang-tidy-14
+          sudo apt-get install -y --no-install-recommends libc++-14-dev libc++abi-14-dev clang-tidy-14 libclang-common-14-dev libclang-rt-14-dev
 
       - name: Install Valgrind
         if: matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-10'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS build
+FROM alpine:3.17 AS build
 
 RUN apk add --no-cache build-base cmake ninja git linux-headers
 
@@ -22,7 +22,7 @@ RUN mkdir /build \
   && rm -rf /build
 
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 RUN apk add --no-cache libstdc++ \
   && addgroup -S ppr \

--- a/include/ppr/common/enums.h
+++ b/include/ppr/common/enums.h
@@ -37,6 +37,7 @@ enum class street_type : uint8_t {
   STAIRS,
   ESCALATOR,
   MOVING_WALKWAY,
+  PLATFORM,
   // edge_type = STREET
   SERVICE,
   PEDESTRIAN,

--- a/include/ppr/output/geojson/edge_info.h
+++ b/include/ppr/output/geojson/edge_info.h
@@ -69,6 +69,7 @@ void write_street_type(Writer& writer, street_type const type) {
     case street_type::MOVING_WALKWAY: writer.String("moving_walkway"); break;
     case street_type::RAIL: writer.String("rail"); break;
     case street_type::TRAM: writer.String("tram"); break;
+    case street_type::PLATFORM: writer.String("platform"); break;
   }
 }
 

--- a/src/backend/output/route_response.cc
+++ b/src/backend/output/route_response.cc
@@ -64,6 +64,7 @@ char const* street_type_str(street_type const street) {
     case street_type::MOVING_WALKWAY: return "moving_walkway";
     case street_type::RAIL: return "rail";
     case street_type::TRAM: return "tram";
+    case street_type::PLATFORM: return "platform";
   }
   throw std::runtime_error{"invalid street type"};
 }

--- a/src/preprocessing/osm_graph/extractor.cc
+++ b/src/preprocessing/osm_graph/extractor.cc
@@ -235,6 +235,7 @@ osm_graph extract(std::string const& osm_file, options const& opt, logging& log,
   filter.add_rule(true, "area:highway", "pedestrian");
   filter.add_rule(true, "public_transport", "platform");
   filter.add_rule(true, "highway", "platform");
+  filter.add_rule(true, "railway", "platform");
   osmium::area::MultipolygonManager<osmium::area::Assembler> mp_manager{
       assembler_config, filter};
   std::unordered_set<osmium::object_id_type> multipolygon_ways;


### PR DESCRIPTION
Trying to find a route using osm_ids of nodes is no longer possible. Areas and Edges saved inside a hash_map so the lookup from id to edge* or area* is significantly faster now.